### PR TITLE
feat: harden quota probe retries and toast signaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Flags for `opencode-codex-usage`:
 - `--json` or `--verbose` - print JSON snapshot to stdout on success.
 - `--pretty` - show a human-friendly quota view with ASCII usage bars.
 - `--no-notify` - skip the refresh notification step.
+- `--retry <count>` - retry transient probe failures (`0-2`). Overrides env for current run.
 - `--setup` - update OpenCode config with plugin path only.
 - `--config <path>` - with `--setup`, use a non-default OpenCode config path.
 - On error, JSON is written to stderr and the process exits non-zero.
@@ -99,7 +100,7 @@ npm unlink -g opencode-codex-usage
 ## Behavior
 
 - Background checks run on startup and on interval.
-- Background checks trigger a toast only when status meets the configured threshold.
+- Background checks trigger a toast only when status meets the configured threshold and gets worse than the previous background state.
 - Manual runs can trigger an immediate refresh from any folder.
 - Window labels use API-provided window minutes when available (for example `5h window`, `7d window`), otherwise fallback to `window A` / `window B`.
 
@@ -124,6 +125,14 @@ OPENCODE_CODEX_QUOTA_POLL_MS=120000
 ```
 
 Default is `600000` (10 minutes). Invalid or non-positive values fall back to default.
+
+Set transient retry count for probe failures:
+
+```bash
+OPENCODE_CODEX_QUOTA_RETRY_COUNT=1
+```
+
+Allowed values: `0`, `1` (default), `2`. Values above `2` clamp to `2`; invalid values fall back to default.
 
 Advanced: override the internal refresh path (optional):
 
@@ -159,6 +168,13 @@ Common keys:
 - `reset` (`primary`/`secondary` reset duration)
 - `windowMinutes` (`primary`/`secondary` window length in minutes, when available)
 - `plan`, `profile`, `probeTokens`, `error`
+
+Error `statusCode` values:
+
+- `auth` for auth-path/token issues
+- `network` for transport failures
+- `timeout` for request timeout
+- numeric HTTP status codes for server responses
 
 Example:
 

--- a/lib/codex-usage-cli.ts
+++ b/lib/codex-usage-cli.ts
@@ -11,6 +11,7 @@ export type CliOptions = {
   noNotify: boolean;
   pretty: boolean;
   printJson: boolean;
+  retryCount?: number;
   setup: boolean;
   setupConfigPath?: string;
 };
@@ -25,6 +26,7 @@ const helpText = () => {
     "  --verbose         Alias for --json",
     "  --pretty          Show human-friendly quota output",
     "  --no-notify       Skip writing trigger signal file",
+    "  --retry <count>   Retry transient probe failures (0-2)",
     "  --setup           Add plugin path to OpenCode config",
     "  --config <path>   Config file path to use with --setup",
     "",
@@ -210,11 +212,24 @@ const wantsJsonOutput = (argv: string[]): boolean => {
   return argv.some((arg) => arg === "--json" || arg === "--verbose");
 };
 
+const parseRetryCount = (raw: string): number => {
+  const normalized = raw.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error("--retry requires an integer between 0 and 2");
+  }
+  const parsed = Number.parseInt(normalized, 10);
+  if (parsed < 0 || parsed > 2) {
+    throw new Error("--retry requires a value between 0 and 2");
+  }
+  return parsed;
+};
+
 export const parseCliOptions = (argv: string[]): CliOptions => {
   let help = false;
   let noNotify = false;
   let pretty = false;
   let printJson = false;
+  let retryCount: number | undefined;
   let setup = false;
   let setupConfigPath: string | undefined;
 
@@ -246,6 +261,21 @@ export const parseCliOptions = (argv: string[]): CliOptions => {
       continue;
     }
 
+    if (arg === "--retry") {
+      const rawValue = argv[idx + 1];
+      if (!rawValue || rawValue.startsWith("--")) {
+        throw new Error("--retry requires a value");
+      }
+      retryCount = parseRetryCount(rawValue);
+      idx += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--retry=")) {
+      retryCount = parseRetryCount(arg.slice("--retry=".length));
+      continue;
+    }
+
     if (arg === "--config") {
       const rawValue = argv[idx + 1];
       if (!rawValue || rawValue.startsWith("--")) {
@@ -262,7 +292,7 @@ export const parseCliOptions = (argv: string[]): CliOptions => {
     }
   }
 
-  return { help, noNotify, pretty, printJson, setup, setupConfigPath };
+  return { help, noNotify, pretty, printJson, retryCount, setup, setupConfigPath };
 };
 
 export const runCli = async (argv: string[] = process.argv.slice(2)): Promise<void> => {
@@ -281,7 +311,7 @@ export const runCli = async (argv: string[] = process.argv.slice(2)): Promise<vo
     return;
   }
 
-  const snapshot = await probeQuota();
+  const snapshot = await probeQuota({ retryCount: options.retryCount });
   const state = statusState(snapshot.status);
   const hasError = state === "error";
   const line = formatProbeOutput(snapshot, {

--- a/lib/codex-usage-probe.ts
+++ b/lib/codex-usage-probe.ts
@@ -1,7 +1,13 @@
 import { readFile } from "node:fs/promises";
 import { z } from "zod";
 import { resolveAuthPath } from "./auth-path.js";
-import { durationText, extractCompletedUsageFromSse, healthLabel, val } from "./quota-format.js";
+import {
+  durationText,
+  extractCompletedUsageFromSse,
+  healthLabel,
+  statusState,
+  val,
+} from "./quota-format.js";
 
 type AuthFile = {
   openai?: {
@@ -35,6 +41,8 @@ const errorMessage = (error: unknown): string => {
 
 const CODEX_URL = "https://chatgpt.com/backend-api/codex/responses";
 const REQUEST_TIMEOUT_MS = 15_000;
+const RETRY_COUNT_ENV = "OPENCODE_CODEX_QUOTA_RETRY_COUNT";
+const MAX_RETRY_COUNT = 2;
 
 type WindowPair<T> = {
   primary: T;
@@ -51,6 +59,17 @@ export type ProbeSnapshot = {
   profile?: string;
   probeTokens?: number;
   error?: string;
+};
+
+export type ProbeQuotaOptions = {
+  retryCount?: number;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+  credentials?: {
+    accessToken: string;
+    accountId?: string;
+  };
 };
 
 const toProbeError = (
@@ -70,9 +89,67 @@ const parseOptionalInt = (raw: string): number | null => {
   return Number.isFinite(parsed) ? parsed : null;
 };
 
-const parseOptionalDuration = (secondsRaw: string): string | null => {
-  const value = durationText(secondsRaw);
+export const normalizeUsagePercent = (raw: string): number | null => {
+  const parsed = Number.parseFloat(raw.trim());
+  if (!Number.isFinite(parsed)) return null;
+
+  const normalized = parsed >= 0 && parsed <= 1 ? parsed * 100 : parsed;
+  const bounded = Math.max(0, Math.min(100, normalized));
+  return Math.round(bounded);
+};
+
+export const normalizeResetValue = (raw: string, nowMs = Date.now()): string | null => {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+
+  const parsed = Number.parseFloat(trimmed);
+  if (!Number.isFinite(parsed)) {
+    const fallback = durationText(trimmed);
+    return fallback === "-" ? null : fallback;
+  }
+
+  let secondsRemaining = parsed;
+  if (parsed > 1_000_000_000_000) {
+    secondsRemaining = (parsed - nowMs) / 1000;
+  } else if (parsed > 1_000_000_000) {
+    secondsRemaining = parsed - nowMs / 1000;
+  }
+
+  const value = durationText(String(Math.max(0, Math.floor(secondsRemaining))));
   return value === "-" ? null : value;
+};
+
+const parseOptionalDuration = (secondsRaw: string, nowMs: number): string | null => {
+  return normalizeResetValue(secondsRaw, nowMs);
+};
+
+const parseRetryCount = (raw: string | undefined, fallback = 1): number => {
+  const parsed = Number.parseInt((raw ?? "").trim(), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.min(parsed, MAX_RETRY_COUNT);
+};
+
+export const resolveProbeRetryCount = (
+  env: NodeJS.ProcessEnv = process.env,
+  fallback = 1,
+): number => {
+  return parseRetryCount(env[RETRY_COUNT_ENV], fallback);
+};
+
+const shouldRetryStatusCode = (statusCode: number | string | undefined): boolean => {
+  if (statusCode === "network" || statusCode === "timeout") return true;
+  if (typeof statusCode === "number") {
+    if (statusCode >= 500) return true;
+    if (statusCode === 408 || statusCode === 409 || statusCode === 425 || statusCode === 429) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const isRetryableProbeFailure = (snapshot: ProbeSnapshot): boolean => {
+  if (statusState(snapshot.status) !== "error") return false;
+  return shouldRetryStatusCode(snapshot.statusCode);
 };
 
 const percentText = (value: number | null | undefined): string => {
@@ -191,7 +268,17 @@ export const formatProbeOutput = (
   return JSON.stringify(snapshot, null, options.printJson ? 2 : 0);
 };
 
-export const probeQuota = async (): Promise<ProbeSnapshot> => {
+const loadCredentials = async (
+  options: ProbeQuotaOptions,
+): Promise<{ access: string; accountId: string } | ProbeSnapshot> => {
+  if (options.credentials) {
+    const access = options.credentials.accessToken.trim();
+    if (access === "") {
+      return toProbeError("error", "missing access token", "auth");
+    }
+    return { access, accountId: options.credentials.accountId ?? "" };
+  }
+
   let access = "";
   let accountId = "";
 
@@ -210,6 +297,18 @@ export const probeQuota = async (): Promise<ProbeSnapshot> => {
     return toProbeError("error", detail.slice(0, 120), "auth");
   }
 
+  return { access, accountId };
+};
+
+const runProbeAttempt = async (
+  access: string,
+  accountId: string,
+  options: {
+    timeoutMs: number;
+    fetchImpl: typeof fetch;
+    nowMs: number;
+  },
+): Promise<ProbeSnapshot> => {
   const body = {
     model: "gpt-5.1-codex",
     instructions: "You are a coding assistant.",
@@ -218,13 +317,13 @@ export const probeQuota = async (): Promise<ProbeSnapshot> => {
     stream: true,
   };
 
-  const timeoutSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const timeoutSignal = AbortSignal.timeout(options.timeoutMs);
 
   let response: Response;
   let responseText = "";
 
   try {
-    response = await fetch(CODEX_URL, {
+    response = await options.fetchImpl(CODEX_URL, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${access}`,
@@ -241,7 +340,7 @@ export const probeQuota = async (): Promise<ProbeSnapshot> => {
     responseText = await response.text();
   } catch (error) {
     if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
-      return toProbeError("error", `request timed out after ${REQUEST_TIMEOUT_MS}ms`, "timeout");
+      return toProbeError("error", `request timed out after ${options.timeoutMs}ms`, "timeout");
     }
 
     const detail = errorMessage(error);
@@ -256,7 +355,6 @@ export const probeQuota = async (): Promise<ProbeSnapshot> => {
   const usage = extractCompletedUsageFromSse(responseText);
   const primaryUsedRaw = val(response.headers, "x-codex-primary-used-percent", "");
   const secondaryUsedRaw = val(response.headers, "x-codex-secondary-used-percent", "");
-  const state = healthLabel(primaryUsedRaw, secondaryUsedRaw);
   const primaryResetSeconds = val(response.headers, "x-codex-primary-reset-after-seconds", "");
   const secondaryResetSeconds = val(response.headers, "x-codex-secondary-reset-after-seconds", "");
   const primaryWindowMinutesRaw = val(response.headers, "x-codex-primary-window-minutes", "");
@@ -264,13 +362,18 @@ export const probeQuota = async (): Promise<ProbeSnapshot> => {
   const plan = val(response.headers, "x-codex-plan-type");
   const profile = val(response.headers, "x-codex-bengalfox-limit-name");
   const probeTokens = usage?.total_tokens ?? 0;
-  const primaryUsed = parseOptionalInt(primaryUsedRaw);
-  const secondaryUsed = parseOptionalInt(secondaryUsedRaw);
-  const primaryReset = parseOptionalDuration(primaryResetSeconds);
-  const secondaryReset = parseOptionalDuration(secondaryResetSeconds);
+  const primaryUsed = normalizeUsagePercent(primaryUsedRaw) ?? parseOptionalInt(primaryUsedRaw);
+  const secondaryUsed =
+    normalizeUsagePercent(secondaryUsedRaw) ?? parseOptionalInt(secondaryUsedRaw);
+  const primaryReset = parseOptionalDuration(primaryResetSeconds, options.nowMs);
+  const secondaryReset = parseOptionalDuration(secondaryResetSeconds, options.nowMs);
   const primaryWindowMinutes = parseOptionalInt(primaryWindowMinutesRaw);
   const secondaryWindowMinutes = parseOptionalInt(secondaryWindowMinutesRaw);
   const hasWindowMinutes = primaryWindowMinutes !== null || secondaryWindowMinutes !== null;
+  const state =
+    primaryUsed !== null && secondaryUsed !== null
+      ? healthLabel(String(primaryUsed), String(secondaryUsed))
+      : healthLabel(primaryUsedRaw, secondaryUsedRaw);
 
   return {
     status: state,
@@ -284,6 +387,38 @@ export const probeQuota = async (): Promise<ProbeSnapshot> => {
       : {}),
     probeTokens,
   };
+};
+
+export const probeQuota = async (options: ProbeQuotaOptions = {}): Promise<ProbeSnapshot> => {
+  const retryCount = Math.min(
+    options.retryCount ?? resolveProbeRetryCount(options.env),
+    MAX_RETRY_COUNT,
+  );
+  const timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const nowMs = Date.now();
+
+  const credentials = await loadCredentials(options);
+  if ("status" in credentials) {
+    return credentials;
+  }
+
+  let snapshot = await runProbeAttempt(credentials.access, credentials.accountId, {
+    timeoutMs,
+    fetchImpl,
+    nowMs,
+  });
+
+  for (let attempt = 0; attempt < retryCount; attempt += 1) {
+    if (!isRetryableProbeFailure(snapshot)) break;
+    snapshot = await runProbeAttempt(credentials.access, credentials.accountId, {
+      timeoutMs,
+      fetchImpl,
+      nowMs,
+    });
+  }
+
+  return snapshot;
 };
 
 export const probeQuotaLine = async (): Promise<string> => {

--- a/lib/codex-usage-toast-plugin.ts
+++ b/lib/codex-usage-toast-plugin.ts
@@ -254,6 +254,16 @@ export const shouldToastForBackground = (
   return STATUS_SEVERITY_RANK[state] >= thresholdRank;
 };
 
+export const shouldToastForBackgroundTransition = (
+  currentStatus: string | undefined,
+  previousStatus: string | undefined,
+): boolean => {
+  const current = statusStateNormalized(currentStatus);
+  const previous = previousStatus ? statusStateNormalized(previousStatus) : undefined;
+  if (!previous) return true;
+  return STATUS_SEVERITY_RANK[current] > STATUS_SEVERITY_RANK[previous];
+};
+
 const windowLabelFromMinutes = (minutes: number | undefined, fallback: string): string => {
   if (!minutes || !Number.isFinite(minutes) || minutes <= 0) return fallback;
 
@@ -345,6 +355,7 @@ export const CodexQuotaToastPlugin = ({ client, worktree }: PluginContext) => {
   let running = false;
   let pendingForce = false;
   let started = false;
+  let lastBackgroundStatus: QuotaStatusState | undefined;
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let triggerTimer: ReturnType<typeof setInterval> | undefined;
   const signalPath = resolveSignalPath();
@@ -416,9 +427,21 @@ export const CodexQuotaToastPlugin = ({ client, worktree }: PluginContext) => {
         return { failed: true, detail: probeError };
       }
 
-      if (!force && !shouldToastForBackground(parsed.status, toastThreshold)) {
-        return { failed: false };
+      const normalizedStatus = statusStateNormalized(parsed.status);
+      if (!force) {
+        const shouldToastByThreshold = shouldToastForBackground(parsed.status, toastThreshold);
+        const shouldToastByTransition = shouldToastForBackgroundTransition(
+          normalizedStatus,
+          lastBackgroundStatus,
+        );
+        lastBackgroundStatus = normalizedStatus;
+        if (!shouldToastByThreshold || !shouldToastByTransition) {
+          return { failed: false };
+        }
+      } else {
+        lastBackgroundStatus = normalizedStatus;
       }
+
       await client.tui.showToast({
         body: {
           title: toastTitleForStatus(parsed.status),
@@ -528,6 +551,7 @@ export const CodexQuotaToastPlugin = ({ client, worktree }: PluginContext) => {
 
   const stopBackgroundWorkersAndReset = (): void => {
     started = false;
+    lastBackgroundStatus = undefined;
     stopBackgroundWorkers();
   };
 

--- a/tests/codex-usage-cli.test.ts
+++ b/tests/codex-usage-cli.test.ts
@@ -8,6 +8,7 @@ test("parseCliOptions uses silent-json defaults", () => {
     noNotify: false,
     pretty: false,
     printJson: false,
+    retryCount: undefined,
     setup: false,
     setupConfigPath: undefined,
   });
@@ -19,6 +20,7 @@ test("parseCliOptions recognizes output and notify flags", () => {
     noNotify: true,
     pretty: false,
     printJson: true,
+    retryCount: undefined,
     setup: false,
     setupConfigPath: undefined,
   });
@@ -27,6 +29,7 @@ test("parseCliOptions recognizes output and notify flags", () => {
     noNotify: false,
     pretty: false,
     printJson: true,
+    retryCount: undefined,
     setup: false,
     setupConfigPath: undefined,
   });
@@ -38,6 +41,7 @@ test("parseCliOptions recognizes pretty output flag", () => {
     noNotify: false,
     pretty: true,
     printJson: true,
+    retryCount: undefined,
     setup: false,
     setupConfigPath: undefined,
   });
@@ -49,6 +53,7 @@ test("parseCliOptions recognizes setup flag", () => {
     noNotify: false,
     pretty: false,
     printJson: false,
+    retryCount: undefined,
     setup: true,
     setupConfigPath: undefined,
   });
@@ -72,4 +77,15 @@ test("parseCliOptions accepts setup config path", () => {
 
 test("parseCliOptions rejects missing config value", () => {
   assert.throws(() => parseCliOptions(["--config"]), /requires a value/);
+});
+
+test("parseCliOptions accepts retry count", () => {
+  assert.equal(parseCliOptions(["--retry", "2"]).retryCount, 2);
+  assert.equal(parseCliOptions(["--retry=0"]).retryCount, 0);
+});
+
+test("parseCliOptions rejects invalid retry count", () => {
+  assert.throws(() => parseCliOptions(["--retry"]), /requires a value/);
+  assert.throws(() => parseCliOptions(["--retry", "abc"]), /integer between 0 and 2/);
+  assert.throws(() => parseCliOptions(["--retry", "9"]), /between 0 and 2/);
 });

--- a/tests/probe-output.test.ts
+++ b/tests/probe-output.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { formatProbeOutput } from "../lib/codex-usage-probe.js";
+import {
+  formatProbeOutput,
+  normalizeResetValue,
+  normalizeUsagePercent,
+  resolveProbeRetryCount,
+} from "../lib/codex-usage-probe.js";
 
 test("formatProbeOutput returns compact JSON by default", () => {
   const line = formatProbeOutput({ status: "ok", statusCode: 200 });
@@ -86,4 +91,28 @@ test("formatProbeOutput aligns values for metadata rows", () => {
   const planValueStart = lines[2]?.indexOf("plus / default") ?? -1;
   assert.equal(quotaValueStart, statusValueStart);
   assert.equal(statusValueStart, planValueStart);
+});
+
+test("normalizeUsagePercent handles decimal and bounded inputs", () => {
+  assert.equal(normalizeUsagePercent("0.81"), 81);
+  assert.equal(normalizeUsagePercent("81"), 81);
+  assert.equal(normalizeUsagePercent("101"), 100);
+  assert.equal(normalizeUsagePercent("-5"), 0);
+  assert.equal(normalizeUsagePercent("nope"), null);
+});
+
+test("normalizeResetValue accepts durations and timestamps", () => {
+  const nowMs = Date.UTC(2026, 0, 1, 0, 0, 0);
+  assert.equal(normalizeResetValue("3600", nowMs), "1h0m");
+  assert.equal(normalizeResetValue(String(Math.floor(nowMs / 1000) + 3600), nowMs), "1h0m");
+  assert.equal(normalizeResetValue(String(nowMs + 3_600_000), nowMs), "1h0m");
+  assert.equal(normalizeResetValue("", nowMs), null);
+});
+
+test("resolveProbeRetryCount parses env and bounds values", () => {
+  assert.equal(resolveProbeRetryCount({}), 1);
+  assert.equal(resolveProbeRetryCount({ OPENCODE_CODEX_QUOTA_RETRY_COUNT: "2" }), 2);
+  assert.equal(resolveProbeRetryCount({ OPENCODE_CODEX_QUOTA_RETRY_COUNT: "9" }), 2);
+  assert.equal(resolveProbeRetryCount({ OPENCODE_CODEX_QUOTA_RETRY_COUNT: "-1" }), 1);
+  assert.equal(resolveProbeRetryCount({ OPENCODE_CODEX_QUOTA_RETRY_COUNT: "abc" }), 1);
 });

--- a/tests/probe-retry.test.ts
+++ b/tests/probe-retry.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isRetryableProbeFailure, probeQuota } from "../lib/codex-usage-probe.js";
+
+const successResponse = (): Response => {
+  return new Response("data: [DONE]\n", {
+    status: 200,
+    headers: {
+      "x-codex-primary-used-percent": "0.81",
+      "x-codex-secondary-used-percent": "9",
+      "x-codex-primary-reset-after-seconds": "3600",
+      "x-codex-secondary-reset-after-seconds": "7200",
+      "x-codex-primary-window-minutes": "300",
+      "x-codex-secondary-window-minutes": "10080",
+      "x-codex-plan-type": "plus",
+      "x-codex-bengalfox-limit-name": "default",
+    },
+  });
+};
+
+test("probeQuota retries once on network failure", async () => {
+  let calls = 0;
+  const fetchImpl: typeof fetch = async () => {
+    calls += 1;
+    if (calls === 1) {
+      throw new Error("network down");
+    }
+    return successResponse();
+  };
+
+  const snapshot = await probeQuota({
+    retryCount: 1,
+    fetchImpl,
+    credentials: { accessToken: "token" },
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(snapshot.status, "warn");
+  assert.deepEqual(snapshot.used, { primary: 81, secondary: 9 });
+});
+
+test("probeQuota does not retry auth/http 401 failures", async () => {
+  let calls = 0;
+  const fetchImpl: typeof fetch = async () => {
+    calls += 1;
+    return new Response("unauthorized", { status: 401 });
+  };
+
+  const snapshot = await probeQuota({
+    retryCount: 2,
+    fetchImpl,
+    credentials: { accessToken: "token" },
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(snapshot.status, "error");
+  assert.equal(snapshot.statusCode, 401);
+});
+
+test("probeQuota does not retry when retry count is disabled", async () => {
+  let calls = 0;
+  const fetchImpl: typeof fetch = async () => {
+    calls += 1;
+    throw new Error("network down");
+  };
+
+  const snapshot = await probeQuota({
+    retryCount: 0,
+    fetchImpl,
+    credentials: { accessToken: "token" },
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(snapshot.statusCode, "network");
+});
+
+test("isRetryableProbeFailure follows transient-only policy", () => {
+  assert.equal(isRetryableProbeFailure({ status: "error", statusCode: "network" }), true);
+  assert.equal(isRetryableProbeFailure({ status: "error", statusCode: "timeout" }), true);
+  assert.equal(isRetryableProbeFailure({ status: "error", statusCode: 503 }), true);
+  assert.equal(isRetryableProbeFailure({ status: "error", statusCode: 429 }), true);
+  assert.equal(isRetryableProbeFailure({ status: "error", statusCode: 401 }), false);
+  assert.equal(isRetryableProbeFailure({ status: "warn", statusCode: 503 }), false);
+});

--- a/tests/toast-threshold.test.ts
+++ b/tests/toast-threshold.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   resolveToastThreshold,
   shouldToastForBackground,
+  shouldToastForBackgroundTransition,
   type ToastThreshold,
 } from "../lib/codex-usage-toast-plugin.js";
 
@@ -40,4 +41,14 @@ test("filters background toasts by threshold", () => {
   for (const check of checks) {
     assert.equal(shouldToastForBackground(check.status, check.threshold), check.expected);
   }
+});
+
+test("background transition toasts only on worsening status", () => {
+  assert.equal(shouldToastForBackgroundTransition("warn", undefined), true);
+  assert.equal(shouldToastForBackgroundTransition("warn", "ok"), true);
+  assert.equal(shouldToastForBackgroundTransition("critical", "warn"), true);
+  assert.equal(shouldToastForBackgroundTransition("error", "critical"), true);
+  assert.equal(shouldToastForBackgroundTransition("warn", "warn"), false);
+  assert.equal(shouldToastForBackgroundTransition("ok", "warn"), false);
+  assert.equal(shouldToastForBackgroundTransition("warn", "critical"), false);
 });


### PR DESCRIPTION
## Summary
- add defensive probe normalization for percentage and reset values, including timestamp-derived reset handling
- add selective retry support for transient failures with CLI/env overrides (`--retry`, `OPENCODE_CODEX_QUOTA_RETRY_COUNT`)
- reduce toast noise by only showing background toasts when status worsens while preserving forced/manual notifications
- extend tests for retry policy, normalization behavior, transition gating, and CLI parsing; update README docs